### PR TITLE
Update dependencies

### DIFF
--- a/default.txt
+++ b/default.txt
@@ -9,6 +9,6 @@ requests>=2.12.3
 celery>=4.0.0rc3
 #PyConfigure>=0.5.9
 # Using this fork until this gets merged https://github.com/alfred82santa/configure/pull/5
-git+https://github.com/TheAbhijeet/configure.git
+git+https://github.com/TheAbhijeet/configure.git@2d3dce73d7acab7ac01016ec633fb4019c62b0e9
 attrs==18.2.0
 marshmallow>=3.3.0

--- a/default.txt
+++ b/default.txt
@@ -7,6 +7,8 @@ PyYaml==5.1.2
 PyStaticConfiguration>=0.10.2
 requests>=2.12.3
 celery>=4.0.0rc3
-PyConfigure>=0.5.9
+#PyConfigure>=0.5.9
+# Using this fork until this gets merged https://github.com/alfred82santa/configure/pull/5
+git+https://github.com/TheAbhijeet/configure.git
 attrs==18.2.0
 marshmallow>=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 -r default.txt
 gunicorn==19.6.0
 sphinx==1.5.1
-sphinx-autobuild==0.6.0
+sphinx-autobuild==2021.3.14
 sphinx_rtd_theme==0.1.9
 coverage==4.1
 codacy-coverage==1.2.18
 freezegun==0.3.11
 setuptools>=27
-boto3==1.9.87
-awscli==1.16.15
-ipdb==0.12.2
+boto3==1.21.35
+awscli==1.22.90
+ipdb==0.13.9
 twine==1.15.0
 # using mwaaas branch here as we wait for this pull request to be merged
 # https://github.com/steven-bruce-au/dynamodb-local-cloud-formation/pull/4


### PR DESCRIPTION
## Changelog

Dependencies Updated

The package `PyConfigure` has not been updated in the last 4 years therefore is incompatible with Python 3.10. 

## Notes
This repository does not run unit tests on Pull requests, so if anything broke we will only learn about it at a later step when USSD pulls the package.