### PR TITLE
Fix installation issue

### DIFF
--- a/default.txt
+++ b/default.txt
@@ -10,4 +10,4 @@ celery>=4.0.0rc3
 # PyConfigure>=0.5.9
 attrs==18.2.0
 marshmallow>=3.3.0
-configure-fork
+configure-fork>=0.7

--- a/default.txt
+++ b/default.txt
@@ -10,4 +10,5 @@ celery>=4.0.0rc3
 # PyConfigure>=0.5.9
 attrs==18.2.0
 marshmallow>=3.3.0
-configure-fork>=0.7
+# Using this fork until this gets merged https://github.com/alfred82santa/configure/pull/5
+configure-fork @ https://github.com/TheAbhijeet/configure/archive/refs/tags/0.7.tar.gz#egg=configure-fork-0.7

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     url='https://github.com/ussd-airflow/ussd_engine',
     install_requires=reqs('default.txt'),
     # Using this fork until this gets merged https://github.com/alfred82santa/configure/pull/5
-    dependency_links=['https://github.com/TheAbhijeet/configure/archive/refs/tags/0.7.tar.gz#egg=configure-fork'],
+    dependency_links=['https://github.com/TheAbhijeet/configure/archive/refs/tags/0.7.tar.gz#egg=configure-fork-0.7'],
     include_package_data=True,
     license='MIT',
     author='Mwas',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     url='https://github.com/ussd-airflow/ussd_engine',
     install_requires=reqs('default.txt'),
     # Using this fork until this gets merged https://github.com/alfred82santa/configure/pull/5
-    dependency_links=['https://github.com/TheAbhijeet/configure/archive/refs/tags/0.6.tar.gz#egg=configure-fork'],
+    dependency_links=['https://github.com/TheAbhijeet/configure/archive/refs/tags/0.7.tar.gz#egg=configure-fork'],
     include_package_data=True,
     license='MIT',
     author='Mwas',

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(
     packages=find_packages(exclude=('ussd_airflow',)),
     url='https://github.com/ussd-airflow/ussd_engine',
     install_requires=reqs('default.txt'),
-    # Using this fork until this gets merged https://github.com/alfred82santa/configure/pull/5
-    dependency_links=['https://github.com/TheAbhijeet/configure/archive/refs/tags/0.7.tar.gz#egg=configure-fork-0.7'],
     include_package_data=True,
     license='MIT',
     author='Mwas',


### PR DESCRIPTION
`dependency_links` have been removed from the latest versions of PIP